### PR TITLE
Sort members and projects alphabetically

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -28,9 +28,17 @@ export const Home = () => {
     useEffect(() => {
         const fetchData = async () => {
             const projectSnap = await getDocs(collection(db, 'projects'));
-            setProjects(projectSnap.docs.map((d) => d.data()));
+            setProjects(
+                projectSnap.docs
+                    .map((d) => d.data())
+                    .sort((a, b) => a.title.localeCompare(b.title))
+            );
             const memberSnap = await getDocs(collection(db, 'members'));
-            setMembers(memberSnap.docs.map((d) => d.data()));
+            setMembers(
+                memberSnap.docs
+                    .map((d) => d.data())
+                    .sort((a, b) => a.name.localeCompare(b.name))
+            );
         };
         fetchData().catch(console.error);
     }, []);


### PR DESCRIPTION
## Summary
- ensure member and project lists are sorted alphabetically when fetched

## Testing
- `npm run lint` *(fails: cannot download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68695dcc94a083298b9fc1574f1f6e4c